### PR TITLE
Support for Catch2 tests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "contrib/Catch2"]
+	path = contrib/Catch2
+	url = https://github.com/catchorg/Catch2.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,12 +12,17 @@ option(BUILD_TESTS "Build assignment tests." ON)
 include(CMakePrintHelpers)
 cmake_print_variables(CMAKE_BUILD_TYPE BUILD_TESTS)
 
+# статическая библиотека
+add_library(${PROJECT_NAME}_lib STATIC src/cartesian_tree.cpp)
+target_include_directories(${PROJECT_NAME}_lib PUBLIC include)
+
+# исполняемый файл
 add_executable(${PROJECT_NAME} main.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE ${PROJECT_NAME}_lib)
 
-# Здесь указываются пути до конкретных исходных файлов (через пробел).
-# Указанные исходные файлы войдут в состав исполняемого файла.
-target_sources(${PROJECT_NAME} PRIVATE src/cartesian_tree.cpp)
-
-# Подключение заголовочных файлов.
-# Для подключения собственных заголовочных в любом месте используйте путь <assignment/...>.
-target_include_directories(${PROJECT_NAME} PUBLIC include)
+# Tests
+if (BUILD_TESTS)
+    enable_testing()
+    add_subdirectory(contrib)
+    add_subdirectory(tests)
+endif (BUILD_TESTS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,13 @@ cmake_minimum_required(VERSION 3.20)
 project(untitled3 CXX)
 
 set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_EXTENSIONS ON)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+option(BUILD_TESTS "Build assignment tests." ON)
+
+include(CMakePrintHelpers)
+cmake_print_variables(CMAKE_BUILD_TYPE BUILD_TESTS)
 
 add_executable(${PROJECT_NAME} main.cpp)
 

--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -1,0 +1,11 @@
+# Catch2
+if (NOT EXISTS "${PROJECT_SOURCE_DIR}/contrib/Catch2/CMakeLists.txt")
+    message(FATAL_ERROR "submodule contrib/Catch2 is missing. To fix try run:
+    git submodule update --init --recursive")
+else ()
+    option(CATCH_INSTALL_DOCS "Install docs" OFF)
+    option(CATCH_BUILD_TESTING "Enable testing" OFF)
+    option(CATCH_BUILD_EXAMPLES "Build examples" OFF)
+
+    add_subdirectory(${PROJECT_SOURCE_DIR}/contrib/Catch2 ${CMAKE_CURRENT_BINARY_DIR}/Catch2)
+endif ()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,14 @@
+include(CTest)
+
+set(TARGET_NAME run_tests)
+
+# Executable
+add_executable(${TARGET_NAME} run_tests.cpp)
+target_sources(${TARGET_NAME} PRIVATE test_cases.cpp)
+
+# Catch2
+target_link_libraries(${TARGET_NAME} PRIVATE ${PROJECT_NAME}_lib Catch2::Catch2)
+
+# Discover tests
+include(${PROJECT_SOURCE_DIR}/contrib/Catch2/contrib/Catch.cmake)
+catch_discover_tests(${TARGET_NAME} EXTRA_ARGS -r console --abort)

--- a/tests/run_tests.cpp
+++ b/tests/run_tests.cpp
@@ -1,0 +1,4 @@
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+
+// This file provides with unit tests runner

--- a/tests/test_cases.cpp
+++ b/tests/test_cases.cpp
@@ -1,0 +1,14 @@
+#include "assignment/cartesian_tree.hpp"  // CartesianTree
+
+#include <catch2/catch.hpp>
+
+using assignment::CartesianTree;
+using assignment::Node;
+
+TEST_CASE("CartesianTree constructor") {
+
+  CartesianTree tree;  // default constructor
+
+  CHECK(tree.IsEmpty());  // tree.IsEmpty() == true?
+  CHECK(tree.root() == nullptr);
+}


### PR DESCRIPTION
Добавлена библиотека Catch2 для написания тестов.

Примеры работы с Catch2 можно найти в ваших домашних заданиях и по [ссылке](https://github.com/catchorg/Catch2/blob/devel/docs/tutorial.md#top) на официальную документацию.